### PR TITLE
1. cors 에러 http-proxy-middleware 사용

### DIFF
--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,20 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+const url = "https://www.pre-onboarding-selection-task.shop";
+
+module.exports = function (app) {
+  app.use(
+    "/auth",
+    createProxyMiddleware({
+      target: url,
+      changeOrigin: true,
+    })
+  );
+  app.use(
+    "/todos",
+    createProxyMiddleware({
+      target: url,
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
# * [조건] 기존 axios로 작성된 코드들과 충돌이 없는가?
  ▶  app.use("/auth") 코드는 axios.post("/auth/signin") 이나axios.post("auth/signup")과 연결
  ▶ app.use("/todos") 코드는 utils/todoAPI 안에 있는 axios.get("/todos")나 axios.post("todos/${id})와 연결

## * [알게된 점]

  ▶ 단순히 url 주소만 입력 후 GET이나 POST 요청을 보내면 CORS에러가 나지 않음
  ▶ 허나 API 요청의 조건인 
   `Headers: Content-Type: application/json` 적용하려면 CORS의 충돌을 해결해야 했음
  ▶ 서버 분리 없이 React 내부에서 CORS 에러를 해결하는 방법을 알게 됨
