### PR TITLE
3. Todos - 체크박스 에러 수정

### DIFF
--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -1,6 +1,7 @@
 import TodoItem from "./TodoItem";
 
 const TodoList = ({ todos, setIsEdit, setIsDelete }) => {
+  console.log("todos", todos);
   return (
     <section>
       {todos.map((todo) => (


### PR DESCRIPTION

# * [해결방안] - TodoItem.js
▶ useRef 함수 사용
▶ editCheckbox의 내용을 clickCheckbox와 editCheckbox로 분리

> clickCheckbox : checkbox toggle 부분
> editCheckbox : 체크박스 수정 시 API를 통해 수정

## *  useRef의 사용 이점 
▶ ① 컴포넌트가 마운트 해제 전까지 계속 유지(변경 가능한 .current라는 속성을 가진 하나의 상자)
▶ ② 다양한 변수를 저장할 수 있음 → 자바스크립트 객체 리턴함
▶ ③ 매번 렌더링될 때마다 항상 같은 ref 객체 반환함

## * [어떤식으로 수정?]
▶ 문제가 된 부분은 체크박스가 렌더링 될 때마다 변화한 값이 제대로 적용되지 않아 발생함 
▶ useRef로 정의한 icComponentMounted가 컴포넌트 라이프타임 전체에 걸쳐 유지됨
▶ 즉, 체크박스를 클릭 후 변경 될 때까지 계속 그 상태를 유지함